### PR TITLE
setuptools compilation

### DIFF
--- a/lightning/impl/randomkit/setup.py
+++ b/lightning/impl/randomkit/setup.py
@@ -21,5 +21,5 @@ def configuration(parent_package='', top_path=None):
     return config
 
 if __name__ == '__main__':
-    from numpy.distutils.core import setup
+    from setuptools import setup
     setup(**configuration(top_path='').todict())

--- a/lightning/impl/setup.py
+++ b/lightning/impl/setup.py
@@ -60,5 +60,5 @@ def configuration(parent_package='', top_path=None):
     return config
 
 if __name__ == '__main__':
-    from numpy.distutils.core import setup
+    from setuptools import setup
     setup(**configuration(top_path='').todict())

--- a/lightning/setup.py
+++ b/lightning/setup.py
@@ -13,5 +13,5 @@ def configuration(parent_package='', top_path=None):
     return config
 
 if __name__ == '__main__':
-    from numpy.distutils.core import setup
+    from setuptools import setup
     setup(**configuration(top_path='').todict())

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ DOWNLOAD_URL = 'https://github.com/mblondel/lightning'
 VERSION = '0.1-git'
 
 import setuptools  # we are using a setuptools namespace
-from numpy.distutils.core import setup
+from setuptools import setup
 
 
 def configuration(parent_package='', top_path=None):


### PR DESCRIPTION
The lightning code presents three setup.py files, disposed hierarchically.
At the top level there is lightning/impl/randomkit/setup.py, who contain some cython code together with some .c files. Compiled with `from numpy.distutils.core import setup` gives the usual error 
`AttributeError: LSVCCompiler instance has no attribute compiler_cxx`. If we make the change as highlighted in the pull, we are finally able to compile !

```
C:\Documents\M.casotto\Desktop\AXA_git\lightning>cd lightning/impl/randomkit

C:\Documents\M.casotto\Desktop\AXA_git\lightning\lightning\impl\randomkit>python
 setup.py build_ext --inplace
Warning: Assuming default configuration (.\tests/{setup_tests,setup}.py was not
found)Appending randomkit.tests configuration to randomkit
Ignoring attempt to set 'name' (from 'randomkit' to 'randomkit.tests')
running build_ext
building 'randomkit.random_fast' extension
creating build
creating build\temp.win-amd64-2.7
creating build\temp.win-amd64-2.7\Release
C:\Users\M.casotto\AppData\Local\Programs\Common\Microsoft\Visual C++ for Python
\9.0\VC\Bin\amd64\cl.exe /c /nologo /Ox /MD /W3 /GS- /DNDEBUG -IC:\Users\M.casot
to\AppData\Local\Continuum\Anaconda2\lib\site-packages\numpy\core\include -IC:\U
sers\M.casotto\AppData\Local\Continuum\Anaconda2\include -IC:\Users\M.casotto\Ap
pData\Local\Continuum\Anaconda2\PC /Tp.\random_fast.cpp /Fobuild\temp.win-amd64-
2.7\Release\.\random_fast.obj
Found executable C:\Users\M.casotto\AppData\Local\Programs\Common\Microsoft\Visu
al C++ for Python\9.0\VC\Bin\amd64\cl.exe
C:\Users\M.casotto\AppData\Local\Programs\Common\Microsoft\Visual C++ for Python
\9.0\VC\Bin\amd64\cl.exe /c /nologo /Ox /MD /W3 /GS- /DNDEBUG -IC:\Users\M.casot
to\AppData\Local\Continuum\Anaconda2\lib\site-packages\numpy\core\include -IC:\U
sers\M.casotto\AppData\Local\Continuum\Anaconda2\include -IC:\Users\M.casotto\Ap
pData\Local\Continuum\Anaconda2\PC /Tc.\randomkit.c /Fobuild\temp.win-amd64-2.7\
Release\.\randomkit.obj
creating build\lib.win-amd64-2.7
creating build\lib.win-amd64-2.7\randomkit
C:\Users\M.casotto\AppData\Local\Programs\Common\Microsoft\Visual C++ for Python
\9.0\VC\Bin\amd64\link.exe /DLL /nologo /INCREMENTAL:NO /LIBPATH:C:\Users\M.caso
tto\AppData\Local\Continuum\Anaconda2\libs /LIBPATH:C:\Users\M.casotto\AppData\L
ocal\Continuum\Anaconda2\PCbuild\amd64 /LIBPATH:C:\Users\M.casotto\AppData\Local
\Continuum\Anaconda2\PC\VS9.0\amd64 Advapi32.lib /EXPORT:initrandom_fast build\t
emp.win-amd64-2.7\Release\.\random_fast.obj build\temp.win-amd64-2.7\Release\.\r
andomkit.obj /OUT:build\lib.win-amd64-2.7\randomkit\random_fast.pyd /IMPLIB:buil
d\temp.win-amd64-2.7\Release\.\random_fast.lib /MANIFESTFILE:build\temp.win-amd6
4-2.7\Release\.\random_fast.pyd.manifest /MANIFEST
Found executable C:\Users\M.casotto\AppData\Local\Programs\Common\Microsoft\Visu
al C++ for Python\9.0\VC\Bin\amd64\link.exe
copying build\lib.win-amd64-2.7\randomkit\random_fast.pyd -> .

C:\Documents\M.casotto\Desktop\AXA_git\lightning\lightning\impl\randomkit>python
 setup.py install
Warning: Assuming default configuration (.\tests/{setup_tests,setup}.py was not
found)Appending randomkit.tests configuration to randomkit
Ignoring attempt to set 'name' (from 'randomkit' to 'randomkit.tests')
running install
running bdist_egg
running egg_info
creating randomkit.egg-info
writing randomkit.egg-info\PKG-INFO
writing top-level names to randomkit.egg-info\top_level.txt
writing dependency_links to randomkit.egg-info\dependency_links.txt
writing manifest file 'randomkit.egg-info\SOURCES.txt'
reading manifest file 'randomkit.egg-info\SOURCES.txt'
writing manifest file 'randomkit.egg-info\SOURCES.txt'
installing library code to build\bdist.win-amd64\egg
running install_lib
running build_py
copying .\__init__.py -> build\lib.win-amd64-2.7\randomkit
running build_ext
creating build\bdist.win-amd64
creating build\bdist.win-amd64\egg
creating build\bdist.win-amd64\egg\randomkit
copying build\lib.win-amd64-2.7\randomkit\random_fast.pyd -> build\bdist.win-amd
64\egg\randomkit
copying build\lib.win-amd64-2.7\randomkit\__init__.py -> build\bdist.win-amd64\e
gg\randomkit
byte-compiling build\bdist.win-amd64\egg\randomkit\__init__.py to __init__.pyc
creating stub loader for randomkit\random_fast.pyd
byte-compiling build\bdist.win-amd64\egg\randomkit\random_fast.py to random_fast
.pyc
creating build\bdist.win-amd64\egg\EGG-INFO
copying randomkit.egg-info\PKG-INFO -> build\bdist.win-amd64\egg\EGG-INFO
copying randomkit.egg-info\SOURCES.txt -> build\bdist.win-amd64\egg\EGG-INFO
copying randomkit.egg-info\dependency_links.txt -> build\bdist.win-amd64\egg\EGG
-INFO
copying randomkit.egg-info\top_level.txt -> build\bdist.win-amd64\egg\EGG-INFO
writing build\bdist.win-amd64\egg\EGG-INFO\native_libs.txt
zip_safe flag not set; analyzing archive contents...
creating dist
creating 'dist\randomkit-0.0.0-py2.7-win-amd64.egg' and adding 'build\bdist.win-
amd64\egg' to it
removing 'build\bdist.win-amd64\egg' (and everything under it)
Processing randomkit-0.0.0-py2.7-win-amd64.egg
Removing c:\users\m.casotto\appdata\local\continuum\anaconda2\lib\site-packages\
randomkit-0.0.0-py2.7-win-amd64.egg
Copying randomkit-0.0.0-py2.7-win-amd64.egg to c:\users\m.casotto\appdata\local\
continuum\anaconda2\lib\site-packages
randomkit 0.0.0 is already the active version in easy-install.pth

Installed c:\users\m.casotto\appdata\local\continuum\anaconda2\lib\site-packages
\randomkit-0.0.0-py2.7-win-amd64.egg
Processing dependencies for randomkit==0.0.0
Finished processing dependencies for randomkit==0.0.0

C:\Documents\M.casotto\Desktop\AXA_git\lightning\lightning\impl\randomkit>cd ..

C:\Documents\M.casotto\Desktop\AXA_git\lightning\lightning\impl>ipython
Python 2.7.11 |Anaconda 2.4.1 (64-bit)| (default, Dec  7 2015, 14:10:42) [MSC v.
1500 64 bit (AMD64)]
Type "copyright", "credits" or "license" for more information.

IPython 4.0.1 -- An enhanced Interactive Python.
?         -> Introduction and overview of IPython's features.
%quickref -> Quick reference.
help      -> Python's own help system.
object?   -> Details about 'object', use 'object??' for extra details.

In [1]: import random
random     randomkit  randomkit2

In [1]: import randomkit

In [2]: randomkit.
randomkit.RandomState randomkit.random_fast

In [2]: quit()
```

We move therefore to the lower level (and the one of our interest),i.e. `lightning/impl/setup.py` Unfortunately we are not able to compile and we get the following output

```
C:\Documents\M.casotto\Desktop\AXA_git\lightning\lightning\impl>python setup.py
build_ext --inplace
non-existing path in '.': 'lightning\\impl\\randomkit'
non-existing path in '.': 'lightning\\impl\\randomkit'
non-existing path in '.': 'lightning\\impl\\randomkit'
non-existing path in '.': 'lightning\\impl\\randomkit'
non-existing path in '.': 'lightning\\impl\\randomkit'
non-existing path in '.': 'lightning\\impl\\randomkit'
non-existing path in '.': 'lightning\\impl\\randomkit'
non-existing path in '.': 'lightning\\impl\\randomkit'
non-existing path in '.': 'lightning\\impl\\randomkit'
non-existing path in '.': 'lightning\\impl\\randomkit'
Warning: Assuming default configuration (.\datasets/{setup_datasets,setup}.py wa
s not found)Appending impl.datasets configuration to impl
Ignoring attempt to set 'name' (from 'impl' to 'impl.datasets')
Warning: Assuming default configuration (randomkit\tests/{setup_tests,setup}.py
was not found)Appending impl.randomkit.tests configuration to impl.randomkit
Ignoring attempt to set 'name' (from 'impl.randomkit' to 'impl.randomkit.tests')

Appending impl.randomkit configuration to impl
Ignoring attempt to set 'name' (from 'impl' to 'impl.randomkit')
Warning: Assuming default configuration (.\tests/{setup_tests,setup}.py was not
found)Appending impl.tests configuration to impl
Ignoring attempt to set 'name' (from 'impl' to 'impl.tests')
running build_ext
building 'impl.adagrad_fast' extension
creating build
creating build\temp.win-amd64-2.7
creating build\temp.win-amd64-2.7\Release
C:\Users\M.casotto\AppData\Local\Programs\Common\Microsoft\Visual C++ for Python
\9.0\VC\Bin\amd64\cl.exe /c /nologo /Ox /MD /W3 /GS- /DNDEBUG -IC:\Users\M.casot
to\AppData\Local\Continuum\Anaconda2\lib\site-packages\numpy\core\include -Iligh
tning\impl\randomkit -IC:\Users\M.casotto\AppData\Local\Continuum\Anaconda2\incl
ude -IC:\Users\M.casotto\AppData\Local\Continuum\Anaconda2\PC /Tp.\adagrad_fast.
cpp /Fobuild\temp.win-amd64-2.7\Release\.\adagrad_fast.obj
Found executable C:\Users\M.casotto\AppData\Local\Programs\Common\Microsoft\Visu
al C++ for Python\9.0\VC\Bin\amd64\cl.exe
creating build\lib.win-amd64-2.7
creating build\lib.win-amd64-2.7\impl
C:\Users\M.casotto\AppData\Local\Programs\Common\Microsoft\Visual C++ for Python
\9.0\VC\Bin\amd64\link.exe /DLL /nologo /INCREMENTAL:NO /LIBPATH:C:\Users\M.caso
tto\AppData\Local\Continuum\Anaconda2\libs /LIBPATH:C:\Users\M.casotto\AppData\L
ocal\Continuum\Anaconda2\PCbuild\amd64 /LIBPATH:C:\Users\M.casotto\AppData\Local
\Continuum\Anaconda2\PC\VS9.0\amd64 /EXPORT:initadagrad_fast build\temp.win-amd6
4-2.7\Release\.\adagrad_fast.obj /OUT:build\lib.win-amd64-2.7\impl\adagrad_fast.
pyd /IMPLIB:build\temp.win-amd64-2.7\Release\.\adagrad_fast.lib /MANIFESTFILE:bu
ild\temp.win-amd64-2.7\Release\.\adagrad_fast.pyd.manifest /MANIFEST
Found executable C:\Users\M.casotto\AppData\Local\Programs\Common\Microsoft\Visu
al C++ for Python\9.0\VC\Bin\amd64\link.exe
building 'impl.dataset_fast' extension
C:\Users\M.casotto\AppData\Local\Programs\Common\Microsoft\Visual C++ for Python
\9.0\VC\Bin\amd64\cl.exe /c /nologo /Ox /MD /W3 /GS- /DNDEBUG -IC:\Users\M.casot
to\AppData\Local\Continuum\Anaconda2\lib\site-packages\numpy\core\include -Iligh
tning\impl\randomkit -IC:\Users\M.casotto\AppData\Local\Continuum\Anaconda2\incl
ude -IC:\Users\M.casotto\AppData\Local\Continuum\Anaconda2\PC /Tp.\dataset_fast.
cpp /Fobuild\temp.win-amd64-2.7\Release\.\dataset_fast.obj
C:\Users\M.casotto\AppData\Local\Programs\Common\Microsoft\Visual C++ for Python
\9.0\VC\Bin\amd64\link.exe /DLL /nologo /INCREMENTAL:NO /LIBPATH:C:\Users\M.caso
tto\AppData\Local\Continuum\Anaconda2\libs /LIBPATH:C:\Users\M.casotto\AppData\L
ocal\Continuum\Anaconda2\PCbuild\amd64 /LIBPATH:C:\Users\M.casotto\AppData\Local
\Continuum\Anaconda2\PC\VS9.0\amd64 /EXPORT:initdataset_fast build\temp.win-amd6
4-2.7\Release\.\dataset_fast.obj /OUT:build\lib.win-amd64-2.7\impl\dataset_fast.
pyd /IMPLIB:build\temp.win-amd64-2.7\Release\.\dataset_fast.lib /MANIFESTFILE:bu
ild\temp.win-amd64-2.7\Release\.\dataset_fast.pyd.manifest /MANIFEST
building 'impl.dual_cd_fast' extension
C:\Users\M.casotto\AppData\Local\Programs\Common\Microsoft\Visual C++ for Python
\9.0\VC\Bin\amd64\cl.exe /c /nologo /Ox /MD /W3 /GS- /DNDEBUG -IC:\Users\M.casot
to\AppData\Local\Continuum\Anaconda2\lib\site-packages\numpy\core\include -Iligh
tning\impl\randomkit -IC:\Users\M.casotto\AppData\Local\Continuum\Anaconda2\incl
ude -IC:\Users\M.casotto\AppData\Local\Continuum\Anaconda2\PC /Tp.\dual_cd_fast.
cpp /Fobuild\temp.win-amd64-2.7\Release\.\dual_cd_fast.obj
dual_cd_fast.cpp
c:\users\m.casotto\appdata\local\continuum\anaconda2\lib\site-packages\numpy\cor
e\include\numpy\npy_1_7_deprecated_api.h(12) : Warning Msg: Using deprecated Num
Py API, disable it by #defining NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
.\dual_cd_fast.cpp(350) : fatal error C1083: Cannot open include file: 'randomki
t.h': No such file or directory
error: Command "C:\Users\M.casotto\AppData\Local\Programs\Common\Microsoft\Visua
l C++ for Python\9.0\VC\Bin\amd64\cl.exe /c /nologo /Ox /MD /W3 /GS- /DNDEBUG -I
C:\Users\M.casotto\AppData\Local\Continuum\Anaconda2\lib\site-packages\numpy\cor
e\include -Ilightning\impl\randomkit -IC:\Users\M.casotto\AppData\Local\Continuu
m\Anaconda2\include -IC:\Users\M.casotto\AppData\Local\Continuum\Anaconda2\PC /T
p.\dual_cd_fast.cpp /Fobuild\temp.win-amd64-2.7\Release\.\dual_cd_fast.obj" fail
ed with exit status 2
```

As the init/setup.py was not modified in any other parts except in the import statement, this error is understable.
I tried then to fix such error by trying to modify other parts of the init/setup file

Unable to compile from a top down approach, I tried to compile the setup.py straight from the bottom and I obtained these errors

```
C:\Documents\M.casotto\Desktop\AXA_git\lightning>python setup.py build_ext --inp
lace
C:\Users\M.casotto\AppData\Local\Continuum\Anaconda2\lib\distutils\dist.py:267:
UserWarning: Unknown distribution option: 'configuration'
  warnings.warn(msg)
C:\Users\M.casotto\AppData\Local\Continuum\Anaconda2\lib\site-packages\setuptool
s-18.5-py2.7.egg\setuptools\dist.py:294: UserWarning: The version specified ('0.
1-git') is an invalid version, this may not work as expected with newer versions
 of setuptools, pip, and PyPI. Please see PEP 440 for more details.
running build_ext

C:\Documents\M.casotto\Desktop\AXA_git\lightning>
```
### TL;DR

setuptools is able to see my msvccompiler, but still gives problem for the compilation, mainly for my lack fo knowledge of packages compilation
### Apply cythonize approach?

I post it here just to have a stable reference instead of having it in my mail.

```
2 The most stable one would be to rewrite the setup.py
Actually I am able, after using the instructions contained in  http://stackoverflow.com/questions/28959378/whats-the-official-way-to-get-cython-working-with-enthought-canopy-on-64-bit-wi 
to run some Cython naïve code in my machine using both the approaches on “Compiling with distutils” and “compiling with pyximport” approach (see http://docs.cython.org/src/reference/compilation.html ).
This means that, since you use pyximport to compile your cython code, there should be no problem for the compilation of your package.
To run your code on Windows I suggest  to write a setup.py for a minimal lightning package using the Cythonize function applied on the pyx files, instead of compiling the compiled cpp files as it is done in lightning.
I think that the parts of the lightning library we actually need in our code are 

Lightning 
--- impl
•         sgd_fast.pyx,pxd (for loss and proxy)
•         sag: sag_fast. pyx,pxd (for model.py)
•         dataset_fast.pyx,pxd
-----randomkit                                                       
*        random_fast. pyx,pxd 
```
